### PR TITLE
[nasa/nos3#282] Added include APPLICATION_PLATFORM_INC_LIST

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ add_cfe_app(ds ${APP_SRC_FILES})
 # This permits direct access to public headers in the fsw/inc directory
 target_include_directories(ds PUBLIC fsw/inc)
 
+include_directories(${APPLICATION_PLATFORM_INC_LIST})
+
 set(APP_TABLE_FILES
   fsw/tables/ds_filter_tbl.c
   fsw/tables/ds_file_tbl.c


### PR DESCRIPTION
Added include APPLICATION_PLATFORM_INC_LIST to the DS CMakeList.txt to allow easy reconfiguration per targets in use for build;